### PR TITLE
feat(errors): centralize error handling and translate messages to French for frontend toast display

### DIFF
--- a/backend/src/__tests__/upload.service.spec.ts
+++ b/backend/src/__tests__/upload.service.spec.ts
@@ -27,7 +27,7 @@ describe("UploadService", () => {
 
     await expect(
       service.uploadAvatar(999, Buffer.from("fake-image"))
-    ).rejects.toThrow("User not found");
+    ).rejects.toThrow("User introuvable");
 
     await expect(
       service.uploadAvatar(999, Buffer.from("fake-image"))

--- a/backend/src/__tests__/user.service.spec.ts
+++ b/backend/src/__tests__/user.service.spec.ts
@@ -64,7 +64,7 @@ describe("UserService", () => {
         password: "Password123!",
         passwordConfirm: "Password123!",
       })
-    ).rejects.toThrow("User already exists");
+    ).rejects.toThrow("User existe déjà");
   });
 
   it("should create a new user by admin with role", async () => {
@@ -99,7 +99,7 @@ describe("UserService", () => {
         passwordConfirm: "Password123!",
         roleId: 999,
       })
-    ).rejects.toThrow("Role not found");
+    ).rejects.toThrow("Role introuvable");
   });
 
   it("should delete a user", async () => {
@@ -112,7 +112,7 @@ describe("UserService", () => {
 
   it("should throw error if user not found on delete", async () => {
     (User.findOne as jest.Mock).mockResolvedValueOnce(null);
-    await expect(service.deleteUser(999)).rejects.toThrow("User not found");
+    await expect(service.deleteUser(999)).rejects.toThrow("User introuvable");
   });
 
   it("should return a user by id", async () => {
@@ -125,7 +125,7 @@ describe("UserService", () => {
 
   it("should throw error if user not found by id", async () => {
     (User.findOne as jest.Mock).mockResolvedValueOnce(null);
-    await expect(service.getUserById(999)).rejects.toThrow("User not found");
+    await expect(service.getUserById(999)).rejects.toThrow("User introuvable");
   });
 
   it("should update a user", async () => {
@@ -140,7 +140,7 @@ describe("UserService", () => {
 
   it("should throw error if user not found on update", async () => {
     (User.findOne as jest.Mock).mockResolvedValueOnce(null);
-    await expect(service.updateUser(999, { firstname: "x" })).rejects.toThrow("User not found");
+    await expect(service.updateUser(999, { firstname: "x" })).rejects.toThrow("User introuvable");
   });
 
   it("should update user by admin including role", async () => {
@@ -171,6 +171,6 @@ describe("UserService", () => {
     (User.findOne as jest.Mock).mockResolvedValueOnce(null);
     await expect(
       service.updateUserPassword(999, { password: "x", passwordConfirm: "x" })
-    ).rejects.toThrow("User not found");
+    ).rejects.toThrow("User introuvable");
   });
 });

--- a/backend/src/errors/errors.ts
+++ b/backend/src/errors/errors.ts
@@ -2,11 +2,11 @@ import { AppError } from "./AppError";
 
 export const Errors = {
     notFound: (entity: string) =>
-        new AppError("NOT_FOUND", `${entity} not found`),
+        new AppError("NOT_FOUND", `${entity} introuvable`),
 
     alreadyExists: (entity: string) =>
-        new AppError("ALREADY_EXISTS", `${entity} already exists`),
-    
+        new AppError("ALREADY_EXISTS", `${entity} existe déjà`),
+
     unauthorized: () =>
-        new AppError("UNAUTHORIZED", "You are not authorized"),
+        new AppError("UNAUTHORIZED", "Vous n'êtes pas autorisé"),
 };

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -14,7 +14,7 @@ const upload = multer({
   limits: { fileSize: MAX_FILE_SIZE },
   fileFilter: (_req, file, cb) => {
     if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
-      cb(new Error("Unsupported format. Use JPG, PNG or WebP."));
+      cb(new Error("Format non supporté. Utilisez JPG, PNG ou WebP."));
       return;
     }
     cb(null, true);
@@ -30,12 +30,12 @@ router.post("/upload/avatar/:userId", upload.single("avatar"), async (req, res) 
     const userId = Number(req.params.userId);
 
     if (isNaN(userId)) {
-      res.status(400).json({ error: "Invalid user ID" });
+      res.status(400).json({ error: "ID utilisateur invalide" });
       return;
     }
 
     if (!req.file) {
-      res.status(400).json({ error: "No file provided" });
+      res.status(400).json({ error: "Aucun fichier envoyé" });
       return;
     }
 
@@ -47,7 +47,7 @@ router.post("/upload/avatar/:userId", upload.single("avatar"), async (req, res) 
       return;
     }
     console.error("Avatar upload error:", error);
-    res.status(500).json({ error: "Upload failed" });
+    res.status(500).json({ error: "Échec de l'upload" });
   }
 });
 

--- a/frontend/src/components/UserEditForm.tsx
+++ b/frontend/src/components/UserEditForm.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-toastify";
 import { Camera, User } from "lucide-react";
 import { UPDATE_USER } from "../graphql/operations";
 import type { User as UserType, UpdateUserInput } from "../types/user.types";
+import { handleGraphQLError } from "../utils/handleGraphQLError";
 
 interface UserEditFormProps {
   user: UserType;
@@ -65,10 +66,10 @@ export const UserEditForm = ({ user, onCancel, onSuccess }: UserEditFormProps) =
         toast.success("Photo de profil mise à jour !");
         setAvatarPreview(data.avatar);
       } else {
-        toast.error("Erreur lors de l'upload");
+        toast.error(data.error ?? "Erreur lors de l'upload");
       }
     } catch {
-      toast.error("Erreur lors de l'upload");
+      toast.error("Erreur de connexion au serveur");
     } finally {
       setUploading(false);
     }
@@ -86,21 +87,7 @@ export const UserEditForm = ({ user, onCancel, onSuccess }: UserEditFormProps) =
         onSuccess(data.updateUser);
       }
     } catch (error: any) {
-      const gqlErrors = error?.graphQLErrors || error?.errors;
-      if (gqlErrors?.length) {
-        const firstError = gqlErrors[0];
-        const fields = firstError.extensions?.fields;
-        if (fields?.length) {
-          fields.forEach((field: any) => {
-            const messages = Object.values(field.constraints || {}) as string[];
-            messages.forEach((msg: string) => toast.error(msg));
-          });
-        } else {
-          toast.error(firstError.message);
-        }
-      } else {
-        toast.error("Une erreur est survenue, veuillez réessayer.");
-      }
+      handleGraphQLError(error);
     }
   };
 

--- a/frontend/src/utils/handleGraphQLError.ts
+++ b/frontend/src/utils/handleGraphQLError.ts
@@ -1,0 +1,26 @@
+import { toast } from "react-toastify";
+
+/**
+ * Handles GraphQL errors and displays them in toasts.
+ * Reads validation errors from extensions.fields (class-validator)
+ * and displays each constraint message individually.
+ */
+export function handleGraphQLError(error: any, fallbackMessage = "Une erreur est survenue, veuillez réessayer.") {
+  const gqlErrors = error?.graphQLErrors || error?.errors;
+
+  if (gqlErrors?.length) {
+    const firstError = gqlErrors[0];
+    const fields = firstError.extensions?.fields;
+
+    if (fields?.length) {
+      fields.forEach((field: any) => {
+        const messages = Object.values(field.constraints || {}) as string[];
+        messages.forEach((msg: string) => toast.error(msg));
+      });
+    } else {
+      toast.error(firstError.message);
+    }
+  } else {
+    toast.error(fallbackMessage);
+  }
+}


### PR DESCRIPTION
Centralize backend error handling with AppError and Errors factory, translate all user-facing messages to French (errors, DTOs, upload route), add handleGraphQLError utility on frontend to display errors in toasts automatically, and update all tests to match. Services not using the centralized system (booking, category, product, etc.) were intentionally left as-is.