### PR TITLE
fix(booking): separate user updates from system status transitions

### DIFF
--- a/backend/src/__tests__/booking.service.spec.ts
+++ b/backend/src/__tests__/booking.service.spec.ts
@@ -145,7 +145,7 @@ describe("BookingService", () => {
       id: 1,
       startDate: new Date("2026-01-01"),
       endDate: new Date("2026-01-05"),
-      status: { id: 1, statusName: "En attente" },
+      status: { id: 2, statusName: "À préparer" },
       user: { id: 1 },
       save: jest.fn(),
     };
@@ -182,20 +182,20 @@ describe("BookingService", () => {
     ).rejects.toThrow();
   });
 
-  it("should throw error if booking is not pending on update", async () => {
+  it("should throw error if booking is not 'À préparer' on update", async () => {
     const bookingMock = {
       id: 1,
       startDate: new Date("2026-01-01"),
       endDate: new Date("2026-01-05"),
-      status: { id: 2, statusName: "À préparer" },
+      status: { id: 3, statusName: "En cours" },  
       user: { id: 1 },
       save: jest.fn(),
     };
     (Booking.findOne as jest.Mock).mockResolvedValueOnce(bookingMock);
-
+  
     await expect(
       service.updateBooking(1, { startDate: new Date("2026-01-02") }, 1)
-    ).rejects.toThrow("Seules les réservations en attente peuvent être modifiées");
+    ).rejects.toThrow("Seules les réservations à préparer peuvent être modifiées");  
   });
 
   it("should update booking status", async () => {
@@ -203,19 +203,19 @@ describe("BookingService", () => {
       id: 1,
       startDate: new Date("2026-01-01"),
       endDate: new Date("2026-01-05"),
-      status: { id: 1, statusName: "En attente" },
+      status: { id: 2, statusName: "À préparer" },  
       user: { id: 1 },
       save: jest.fn(),
     };
     (Booking.findOne as jest.Mock).mockResolvedValueOnce(bookingMock);
-
+  
     (Status.findOne as jest.Mock).mockResolvedValueOnce({
       id: 5,
       statusName: "Annulée",
     });
-
+  
     const result = await service.updateBooking(1, { statusId: 5 }, 1);
-
+  
     expect(bookingMock.save).toHaveBeenCalled();
     expect(result.status).toEqual({ id: 5, statusName: "Annulée" });
   });
@@ -233,5 +233,40 @@ describe("BookingService", () => {
     (Booking.findOneBy as jest.Mock).mockResolvedValueOnce(null);
 
     await expect(service.deleteBooking(999)).rejects.toThrow("Booking introuvable");
+  });
+
+  it("should transition a booking to a new status", async () => {
+    const bookingMock = {
+      id: 1,
+      status: { id: 1, statusName: "En attente" },
+      user: { id: 1 },
+      save: jest.fn(),
+    };
+    (Booking.findOne as jest.Mock).mockResolvedValueOnce(bookingMock);
+    (Status.findOne as jest.Mock).mockResolvedValueOnce({
+      id: 2,
+      statusName: "À préparer",
+    });
+
+    const result = await service.transitionStatus(1, 2);
+
+    expect(bookingMock.save).toHaveBeenCalled();
+    expect(result.status).toEqual({ id: 2, statusName: "À préparer" });
+  });
+
+  it("should throw error if booking not found on transitionStatus", async () => {
+    (Booking.findOne as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(service.transitionStatus(999, 2)).rejects.toThrow("Booking introuvable");
+  });
+
+  it("should throw error if status not found on transitionStatus", async () => {
+    (Booking.findOne as jest.Mock).mockResolvedValueOnce({
+      id: 1,
+      status: { id: 1, statusName: "En attente" },
+    });
+    (Status.findOne as jest.Mock).mockResolvedValueOnce(null);
+
+    await expect(service.transitionStatus(1, 999)).rejects.toThrow("Status introuvable");
   });
 });

--- a/backend/src/services/booking.service.ts
+++ b/backend/src/services/booking.service.ts
@@ -114,8 +114,8 @@ export class BookingService {
       throw Errors.unauthorized();
     }
 
-    if (booking.status.statusName !== "En attente") {
-      throw Errors.badRequest("Seules les réservations en attente peuvent être modifiées");
+    if (booking.status.statusName !== "À préparer") {
+      throw Errors.badRequest("Seules les réservations à préparer peuvent être modifiées");
     }
 
     if (data.statusId) {
@@ -132,6 +132,24 @@ export class BookingService {
 
     await booking.save();
     return booking;
+  }
+
+/**
+   * Transitions a booking to a new status. Used by system services 
+   * (e.g., CartService) for status changes that don't require user-side 
+   * validation.
+   * @param bookingId - The booking ID
+   * @param newStatusId - The ID of the new status
+   * @returns The updated booking
+   * @throws NotFoundError if the booking or status does not exist
+   */
+  async transitionStatus(bookingId: number, newStatusId: number): Promise<Booking> {
+   const booking = await this.getBookingById(bookingId);
+   const newStatus = await this.statusService.getStatusById(newStatusId);
+
+   booking.status = newStatus;
+   await booking.save();
+   return booking;
   }
 
   /**

--- a/backend/src/services/cart.service.ts
+++ b/backend/src/services/cart.service.ts
@@ -291,9 +291,7 @@ export class CartService {
     const prepareStatus = await this.statusService.getStatusByName("À préparer");
 
     for (const booking of cartBookings) {
-      await this.bookingService.updateBooking(booking.id, {
-        statusId: prepareStatus.id,
-      }, userId);
+      await this.bookingService.transitionStatus(booking.id, prepareStatus.id);
     }
 
     return cartBookings;

--- a/frontend/src/components/Booking/MyBooking.tsx
+++ b/frontend/src/components/Booking/MyBooking.tsx
@@ -33,6 +33,7 @@ type Booking = {
         productRef: string;
         price: number;
         brand: string;
+        image: string;
       };
     };
   }[];
@@ -72,7 +73,7 @@ const BookingCard = ({ booking, statuses, onUpdate }: {
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [updateBooking, { loading }] = useMutation(UPDATE_BOOKING);
 
-  const isPending = booking.status.statusName === "En attente";
+  const isCancellable = booking.status.statusName === "À préparer";
 
   const handleConfirmCancel = async () => {
     setShowCancelModal(false);
@@ -121,9 +122,9 @@ const BookingCard = ({ booking, statuses, onUpdate }: {
         {booking.bookingsProducts.map((bp, index) => (
           <div key={index} className="flex items-center gap-4">
             <img
-              src={bp.productVariant.image || bp.productVariant.product.name}
-              alt={bp.productVariant.product.name}
-              className="h-16 w-16 object-contain bg-[#fdffe9] rounded-lg p-1 border border-[#acaf91]"
+             src={bp.productVariant.image || bp.productVariant.product.image}
+             alt={bp.productVariant.product.name}
+             className="h-16 w-16 object-contain bg-[#fdffe9] rounded-lg p-1 border border-[#acaf91]"
             />
             <div className="flex-1">
               <p className="text-sm font-medium font-[family-name:var(--font-text)] text-[#31380d]">
@@ -152,7 +153,7 @@ const BookingCard = ({ booking, statuses, onUpdate }: {
         </p>
       </div>
 
-      {isPending && (
+      {isCancellable && (
         <div className="mt-5 pt-4 border-t border-gray-200">
           <button
             onClick={() => setShowCancelModal(true)}
@@ -179,7 +180,12 @@ const BookingCard = ({ booking, statuses, onUpdate }: {
 };
 
 export const MyBookings = () => {
-  const { data, loading, error, refetch } = useQuery<GetMyBookingsData>(GET_MY_BOOKINGS);
+  const { data, loading, error, refetch } = useQuery<GetMyBookingsData>(
+    GET_MY_BOOKINGS,
+    {
+      fetchPolicy: "cache-and-network",
+    }
+  );
   const { data: statusData } = useQuery<GetAllStatusData>(GET_ALL_STATUS);
 
   if (loading) {

--- a/frontend/src/graphql/booking.operations.ts
+++ b/frontend/src/graphql/booking.operations.ts
@@ -40,6 +40,7 @@ export const GET_MY_BOOKINGS = gql`
             productRef
             price
             brand
+            image
           }
         }
       }


### PR DESCRIPTION
fix(booking): allow cancellation in new cart flow + fix image fallback

- Add transitionStatus method for system-level status changes
- Update updateBooking to allow "À préparer" status
- Refactor CartService.validateCart to use transitionStatus
- Fix MyBooking image fallback and add cache-and-network policy
- Add image field to getMyBookings query
- Update and add corresponding unit tests
- Add unit tests for transitionStatus method- 